### PR TITLE
ASB-32468 fix errors related to PR 66

### DIFF
--- a/bibcat/core/grammar.py
+++ b/bibcat/core/grammar.py
@@ -68,12 +68,21 @@ class Grammar(Base):
         if do_verbose:
             print("Initializing instance of Grammar class.")
 
+        paper = Paper(
+            text,
+            keyword_objs=[keyword_obj],
+            dict_ambigs=dict_ambigs,
+            do_check_truematch=do_check_truematch,
+            do_verbose=do_verbose,
+            do_verbose_deep=do_verbose_deep,
+        )
+
         # Process ambig. phrase data, if not given
         if (do_check_truematch) and (dict_ambigs is None):
             # Print some notes
             if do_verbose:
                 print("Processing database of ambiguous phrases...")
-            dict_ambigs = Paper()._process_database_ambig()
+            dict_ambigs = paper._process_database_ambig()
 
         # Otherwise, do nothing new
         else:
@@ -85,14 +94,6 @@ class Grammar(Base):
         if do_verbose:
             print("Processing text using the Paper class...")
 
-        paper = Paper(
-            text,
-            keyword_objs=[keyword_obj],
-            dict_ambigs=dict_ambigs,
-            do_check_truematch=do_check_truematch,
-            do_verbose=do_verbose,
-            do_verbose_deep=do_verbose_deep,
-        )
         paper.process_paragraphs(buffer=buffer)
         self._store_info(paper, "paper")
 

--- a/bibcat/core/paper.py
+++ b/bibcat/core/paper.py
@@ -973,5 +973,3 @@ class Paper(Base):
 
         # Return streamlined text
         return text
-
-    #

--- a/bibcat/tests/core/test_base.py
+++ b/bibcat/tests/core/test_base.py
@@ -8,11 +8,11 @@ import unittest
 
 import numpy as np
 import spacy
-from test_config import test_list_lookup_kobj
 
 from bibcat import config
 from bibcat.core import parameters as params
 from bibcat.core.base import Base
+from bibcat.tests.core.test_config import test_list_lookup_kobj
 
 nlp = spacy.load(config.grammar.spacy_language_model)
 

--- a/bibcat/tests/core/test_base.py
+++ b/bibcat/tests/core/test_base.py
@@ -8,11 +8,11 @@ import unittest
 
 import numpy as np
 import spacy
+from test_config import test_list_lookup_kobj
 
 from bibcat import config
 from bibcat.core import parameters as params
 from bibcat.core.base import Base
-from bibcat.tests.core.test_config import test_list_lookup_kobj
 
 nlp = spacy.load(config.grammar.spacy_language_model)
 
@@ -708,78 +708,4 @@ class TestBase(unittest.TestCase):
                     print("---")
                     print("")
                     #
-                    self.assertEqual(test_res, answer)
-
-    # For tests of _streamline_phrase:
-    if True:
-        # Test streamlining for text with abbreviated phrases
-        def test_streamline_phrase__abbreviations(self):
-            # Prepare text and answers for test
-            dict_tests = {
-                "We plot the data in Fig. 3b and list values in Tab. A.": "We plot the data in Figure 3b and list values in Table A.",
-                "Fig. 4 shows the red vs. blue stars differ in radii.": "Figure 4 shows the red vs blue stars differ in radii.",
-                "There is a fig on the tree. The tree is the Fig Tree.": "There is a fig on the tree. The tree is the Fig Tree.",
-                "Put the ginger beer on my tab.": "Put the ginger beer on my tab.",
-            }
-
-            # Prepare and run tests for bibcat class instance
-            testbase = Base()
-
-            # Check answers
-            for key1 in dict_tests:
-                try:
-                    answer = dict_tests[key1]
-                    test_res = testbase._streamline_phrase(text=key1, do_streamline_etal=True)
-                    self.assertEqual(test_res, answer)
-                except AssertionError:
-                    print("")
-                    print(">")
-                    print("{2}\nTest answer: {0}\nAct. answer: {1}\n".format(test_res, answer, key1))
-                    print("---")
-                    print("")
-
-                    self.assertEqual(test_res, answer)
-
-        # Test streamlining for text with citations
-        def test_streamline_phrase__citations(self):
-            # Prepare text and answers for test
-            dict_tests = {
-                "Somename (2013) published  in SJ.": "{0} published in SJ.".format(
-                    config.textprocessing.placeholder_author
-                ),
-                "Hubble (1953) was a landmark paper (for that subfield).": "{0} was a landmark paper (for that subfield).".format(
-                    config.textprocessing.placeholder_author
-                ),
-                # "See also: Kepler [2023], Hubble & Author (2020), Author, Somename, and Kepler et al. [1990];": "See also: {0}, {0}, {0};".format(
-                #    config.textprocessing.placeholder_author
-                # ), - unrealistic citation case
-                "See also: Kepler [2023], Hubble & Author (2020), Author and Kepler et al. [1990];": "See also: {0};".format(
-                    config.textprocessing.placeholder_author
-                ),
-                "Also Author papers (Author et al. 1997, 2023),": "Also Author papers,",
-                # "(Someone, Author, Somename et al. 1511; 1612)": "", - unrealistic citation case
-                # "(Someone, Author, and Somename et al. 1913,15)": "", - unrealistic citation case
-                "(Author et al. 80; Somename & Author 2012)": "",
-                # "McThatname, Kepler, & Othername [1993] (see our paper)": "{0} (see our paper)".format(
-                #    config.textprocessing.placeholder_author
-                # ), - unrealistic citation case
-                "{Othername et al. 1991} (see Hubble observations)": "(see Hubble observations)",
-            }
-
-            # Prepare and run tests for bibcat class instance
-            testbase = Base()
-
-            # Check answers
-            for key1 in dict_tests:
-                try:
-                    answer = dict_tests[key1]
-                    test_res = testbase._streamline_phrase(text=key1, do_streamline_etal=True)
-                    self.assertEqual(test_res, answer)
-                except AssertionError:
-                    print("")
-                    print(">")
-                    print("{2}\nTest answer: {0}\nAct. answer: {1}\n".format(test_res, answer, key1))
-                    print("---")
-                    print("")
-
                     self.assertEqual(test_res, answer)

--- a/bibcat/tests/core/test_keyword.py
+++ b/bibcat/tests/core/test_keyword.py
@@ -6,10 +6,11 @@ Testing the Paper class and its methods.
 
 import unittest
 
+from test_config import test_dict_lookup_kobj
+
 from bibcat import config
 from bibcat.core import keyword
 from bibcat.core import parameters as params
-from bibcat.tests.core.test_config import test_dict_lookup_kobj
 
 
 class TestKeyword(unittest.TestCase):

--- a/bibcat/tests/core/test_keyword.py
+++ b/bibcat/tests/core/test_keyword.py
@@ -6,11 +6,10 @@ Testing the Paper class and its methods.
 
 import unittest
 
-from test_config import test_dict_lookup_kobj
-
 from bibcat import config
 from bibcat.core import keyword
 from bibcat.core import parameters as params
+from bibcat.tests.core.test_config import test_dict_lookup_kobj
 
 
 class TestKeyword(unittest.TestCase):

--- a/bibcat/tests/core/test_paper.py
+++ b/bibcat/tests/core/test_paper.py
@@ -9,11 +9,11 @@ import unittest
 import numpy as np
 import spacy
 from nltk.corpus import wordnet  # type: ignore
-from test_config import test_dict_lookup_kobj, test_list_lookup_kobj
 
 from bibcat import config
 from bibcat.core import grammar, paper
 from bibcat.core import parameters as params
+from bibcat.tests.core.test_config import test_dict_lookup_kobj, test_list_lookup_kobj
 
 nlp = spacy.load(config.grammar.spacy_language_model)
 

--- a/bibcat/tests/core/test_paper.py
+++ b/bibcat/tests/core/test_paper.py
@@ -9,11 +9,11 @@ import unittest
 import numpy as np
 import spacy
 from nltk.corpus import wordnet  # type: ignore
+from test_config import test_dict_lookup_kobj, test_list_lookup_kobj
 
 from bibcat import config
-from bibcat.core import paper
+from bibcat.core import grammar, paper
 from bibcat.core import parameters as params
-from bibcat.tests.core.test_config import test_dict_lookup_kobj, test_list_lookup_kobj
 
 nlp = spacy.load(config.grammar.spacy_language_model)
 
@@ -119,18 +119,18 @@ class TestPaper(unittest.TestCase):
                 curr_name = curr_kobj.get_name()
 
                 # Prepare and run test for bibcat class instance
-                testbase = paper.Paper(text=curr_text, keyword_objs=test_list_lookup_kobj, do_check_truematch=True)
-                _ = testbase.process_paragraphs(buffer=curr_buffer)
-                test_res = testbase.get_paragraphs()[curr_name]
+                testpaper = paper.Paper(text=curr_text, keyword_objs=test_list_lookup_kobj, do_check_truematch=True)
+                _ = testpaper.process_paragraphs(buffer=curr_buffer)
+                test_res = testpaper.get_paragraphs()[curr_name]
 
-                # ambig_output = testbase._get_info("_results_ambig")[curr_name]
+                # ambig_output = testpaper._get_info("_results_ambig")[curr_name]
                 # test_ambig = [
                 #    (item2["text_wordchunk"], item2["bool"])
                 #    for item1 in ambig_output
                 #    for item2 in item1["info"]
                 #    if (item2["matcher"] is not None)
                 # ]
-                # test_acr_meanings = testbase._get_info("_dict_acronym_meanings")
+                # test_acr_meanings = testpaper._get_info("_dict_acronym_meanings")
 
                 # Check answer
                 try:
@@ -190,8 +190,8 @@ class TestPaper(unittest.TestCase):
                 curr_answer = info["result"]
 
                 # Prepare and run test for bibcat class instance
-                testbase = paper.Paper(text="", keyword_objs=[params.kobj_hubble], do_check_truematch=False)
-                test_res = testbase._buffer_indices(indices=curr_inds, buffer=curr_buffer, max_index=curr_max)
+                testpaper = paper.Paper(text="", keyword_objs=[params.kobj_hubble], do_check_truematch=False)
+                test_res = testpaper._buffer_indices(indices=curr_inds, buffer=curr_buffer, max_index=curr_max)
 
                 # Check answer
                 try:
@@ -243,7 +243,7 @@ class TestPaper(unittest.TestCase):
             }
 
             # Prepare and run tests for bibcat class instance
-            testpaper = paper.Paper()
+            testpaper = paper.Paper(text="", keyword_objs=[params.kobj_hubble], do_check_truematch=False)
             dict_ambigs = testpaper._process_database_ambig(do_verbose=False, keyword_objs=test_list_lookup_kobj)
 
             # Check answers
@@ -317,7 +317,7 @@ class TestPaper(unittest.TestCase):
                 dict_acts[key1]["str_meaning"] = " ".join([" ".join(item) for item in dict_acts[key1]["roots"]])
 
             # Prepare and run test for bibcat class instance
-            testpaper = paper.Paper()
+            testpaper = paper.Paper(text="", keyword_objs=[params.kobj_hubble], do_check_truematch=False)
             for key1 in dict_acts:
                 test_res = testpaper._extract_core_from_phrase(
                     phrase_NLP=nlp(key1),
@@ -371,8 +371,8 @@ class TestPaper(unittest.TestCase):
             ]
 
             # Prepare and run test for bibcat class instance
-            testbase = paper.Paper(text="", keyword_objs=[params.kobj_hubble], do_check_truematch=False)
-            test_res = testbase._split_text(text=text)
+            testpaper = paper.Paper(text="", keyword_objs=[params.kobj_hubble], do_check_truematch=False)
+            test_res = testpaper._split_text(text=text)
             # Check answer
             try:
                 self.assertEqual(test_res, answer)
@@ -385,3 +385,77 @@ class TestPaper(unittest.TestCase):
                 print("")
 
                 self.assertEqual(test_res, answer)
+
+    # For tests of _streamline_phrase:
+    if True:
+        # Test streamlining for text with abbreviated phrases
+        def test_streamline_phrase__abbreviations(self):
+            # Prepare text and answers for test
+            dict_tests = {
+                "We plot the data in Fig. 3b and list values in Tab. A.": "We plot the data in Figure 3b and list values in Table A.",
+                "Fig. 4 shows the red vs. blue stars differ in radii.": "Figure 4 shows the red vs blue stars differ in radii.",
+                "There is a fig on the tree. The tree is the Fig Tree.": "There is a fig on the tree. The tree is the Fig Tree.",
+                "Put the ginger beer on my tab.": "Put the ginger beer on my tab.",
+            }
+
+            # Prepare and run tests for bibcat class instance
+            testpaper = paper.Paper(text="", keyword_objs=test_list_lookup_kobj, do_check_truematch=True)
+
+            # Check answers
+            for key1 in dict_tests:
+                try:
+                    answer = dict_tests[key1]
+                    test_res = testpaper._streamline_phrase(text=key1, do_streamline_etal=True)
+                    self.assertEqual(test_res, answer)
+                except AssertionError:
+                    print("")
+                    print(">")
+                    print("{2}\nTest answer: {0}\nAct. answer: {1}\n".format(test_res, answer, key1))
+                    print("---")
+                    print("")
+
+                    self.assertEqual(test_res, answer)
+
+        # Test streamlining for text with citations
+        def test_streamline_phrase__citations(self):
+            # Prepare text and answers for test
+            dict_tests = {
+                "Somename (2013) published  in SJ.": "{0} published in SJ.".format(
+                    config.textprocessing.placeholder_author
+                ),
+                "Hubble (1953) was a landmark paper (for that subfield).": "{0} was a landmark paper (for that subfield).".format(
+                    config.textprocessing.placeholder_author
+                ),
+                # "See also: Kepler [2023], Hubble & Author (2020), Author, Somename, and Kepler et al. [1990];": "See also: {0}, {0}, {0};".format(
+                #    config.textprocessing.placeholder_author
+                # ), - unrealistic citation case
+                "See also: Kepler [2023], Hubble & Author (2020), Author and Kepler et al. [1990];": "See also: {0};".format(
+                    config.textprocessing.placeholder_author
+                ),
+                "Also Author papers (Author et al. 1997, 2023),": "Also Author papers,",
+                # "(Someone, Author, Somename et al. 1511; 1612)": "", - unrealistic citation case
+                # "(Someone, Author, and Somename et al. 1913,15)": "", - unrealistic citation case
+                "(Author et al. 80; Somename & Author 2012)": "",
+                # "McThatname, Kepler, & Othername [1993] (see our paper)": "{0} (see our paper)".format(
+                #    config.textprocessing.placeholder_author
+                # ), - unrealistic citation case
+                "{Othername et al. 1991} (see Hubble observations)": "(see Hubble observations)",
+            }
+
+            # Prepare and run tests for bibcat class instance
+            testpaper = paper.Paper(text="", keyword_objs=test_list_lookup_kobj, do_check_truematch=True)
+
+            # Check answers
+            for key1 in dict_tests:
+                try:
+                    answer = dict_tests[key1]
+                    test_res = testpaper._streamline_phrase(text=key1, do_streamline_etal=True)
+                    self.assertEqual(test_res, answer)
+                except AssertionError:
+                    print("")
+                    print(">")
+                    print("{2}\nTest answer: {0}\nAct. answer: {1}\n".format(test_res, answer, key1))
+                    print("---")
+                    print("")
+
+                    self.assertEqual(test_res, answer)


### PR DESCRIPTION
Fixes these errors that appeared in #66:

```
FAILED bibcat/tests/core/test_base.py::TestBase::test_streamline_phrase__abbreviations - AttributeError: 'Base' object has no attribute '_streamline_phrase'
FAILED bibcat/tests/core/test_base.py::TestBase::test_streamline_phrase__citations - AttributeError: 'Base' object has no attribute '_streamline_phrase'
FAILED bibcat/tests/core/test_grammar.py::TestGrammar::test__modifs__basic - TypeError: Paper.__init__() missing 3 required positional arguments: 'text'...
FAILED bibcat/tests/core/test_grammar.py::TestGrammar::test__modifs__importantclause_1stperson - TypeError: Paper.__init__() missing 3 required positional arguments: 'text'...
FAILED bibcat/tests/core/test_grammar.py::TestGrammar::test__modifs__importantclause_mission - TypeError: Paper.__init__() missing 3 required positional arguments: 'text'...
FAILED bibcat/tests/core/test_grammar.py::TestGrammar::test__modifs__manyclauses - TypeError: Paper.__init__() missing 3 required positional arguments: 'text'...
FAILED bibcat/tests/core/test_grammar.py::TestGrammar::test__modifs__unimportantclause - TypeError: Paper.__init__() missing 3 required positional arguments: 'text'...
FAILED bibcat/tests/core/test_paper.py::TestPaper::test_check_truematch__variety1 - TypeError: Paper.__init__() missing 3 required positional arguments: 'text'...
FAILED bibcat/tests/core/test_paper.py::TestPaper::test_extract_core_from_phrase__variety - TypeError: Paper.__init__() missing 3 required positional arguments: 'text'...
```